### PR TITLE
fix(npm): optionally skip postinstall download of maxmind free db

### DIFF
--- a/scripts/start-db-download.js
+++ b/scripts/start-db-download.js
@@ -7,6 +7,10 @@ var MaxmindDbDownloader = require('../lib/maxmind-db-downloader');
 var path = require('path');
 
 if (require.main === module) {
+  if (process.env.FXA_GEOIP_SKIP_MAXMIND_DOWNLOAD) {
+    return;
+  }
+
   // start download only when script is
   // executed, not loaded through require.
   var maxmindDbDownloader = new MaxmindDbDownloader();


### PR DESCRIPTION
Provide a way to skip this download, which isn't always the right thing to do.

r? - @vladikoff 