### PR TITLE
fix(data): include ISO 3166 country codes in the result

### DIFF
--- a/lib/location.js
+++ b/lib/location.js
@@ -30,6 +30,7 @@ function Location(locationData, userLocale) {
 
   if (locationData.country) {
     this.country = this.getLocaleSpecificLocationString(locationData.country, userLocale);
+    this.countryCode = locationData.country.iso_code;
   }
 
   if (locationData.subdivisions) {

--- a/test/fxa-geodb.js
+++ b/test/fxa-geodb.js
@@ -71,6 +71,7 @@ describe('fxa-geodb', function () {
     return geoDb(ip)
       .then(function (location) {
         assert.equal(location.country, 'United States', 'Country returned correctly');
+        assert.equal(location.countryCode, 'US', 'Country code returned correctly');
         assert.equal(location.city, 'Mountain View', 'City returned correctly');
         assert.equal(location.continent, 'North America', 'Continent returned correctly');
         assert.deepEqual(location.latLong, latLong, 'LatLong returned correctly');
@@ -96,6 +97,7 @@ describe('fxa-geodb', function () {
     return geoDb(ip)
       .then(function (location) {
         assert.equal(location.country, 'United States', 'Country returned correctly');
+        assert.equal(location.countryCode, 'US', 'Country code returned correctly');
         assert.equal(typeof location.city, 'undefined', 'City undefined');
         assert.equal(location.continent, 'North America', 'Continent returned correctly');
         assert.equal(typeof location.timeZone, 'undefined', 'Timezone undefined');


### PR DESCRIPTION
I want this for the `/sms/status` endpoint in the auth server.

@mozilla/fxa-devs r?