### PR TITLE
feat(api): return location object directly instead of in a promise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
-  - "4"
   - "6"
+  - "8"
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -18,33 +18,51 @@ var geoDb = require('fxa-geodb')({
 
 --
 ### API
-The function returns a promise that may either resolve (on successful finding of location data) or reject (if either the ip was invalid, or location data could not be found). Call the function, like so:
+The function returns a location object
+or throws if the ip was invalid
+or location data could not be found.
+Call the function like so:
 
 ```JavaScript
-geoDb(ip)
-  .then(function (location) {
-    // success, resolved
-    // location data is available here
-  }, function (err) {
-    // rejected :(
-    // Uh-oh error
-  });
+try {
+  const location = geoDb(ip);
+  // Use location...
+} catch (err) {
+  // Handle err
+}
 ```
 
-On successful resolution of the promise, the `location` object has the following data:
+The `location` object has the following properties:
 
-```JavaScript
-accuracy: 'accuracy-radius-in-km', // 5 (number)
-city: 'human-readable-city-name', // Mountain View
-continent: 'human-readable-continent-name', // North America
-country: 'human-readable-country-name', // USA
-latLong: {
-    latitude: 'latitude-in-decimal', // 37.386 (number)
-    longitude: 'longitude-in-decimal' // -122.0838 (number)
-},
-state: 'human-readable-state-name', // Victoria
-stateCode: 'human-readable-state-code', // VIC
-timeZone: 'IANA-compatible-timezone', // America/Los_Angeles 
+* `accuracy`: Accuracy radius in km (number)
+* `city`: Human readable city name (string)
+* `state`: Human readable state name (string)
+* `stateCode`: ISO 3166-2 state code (string)
+* `country`: Human readable country name (string)
+* `countryCode`: ISO 3166-1 alpha-2 country code (string)
+* `continent`: Human readable continent name (string)
+* `timeZone`: IANA tz database timezone (string)
+* `latLong`: An object containing two properties:
+  * `latitude`: Latitude (number)
+  * `longitude`: Longitude (number)
+
+For example:
+
+```js
+{
+  accuracy: 5,
+  city: 'Mountain View',
+  state: 'California',
+  stateCode: 'CA',
+  country: 'United States',
+  countryCode: 'US',
+  continent: 'North America',
+  timeZone: 'America/Los_Angeles'
+  latLong: {
+    latitude: 37.3885,
+    longitude: -122.0741
+  }
+}
 ```
 
 A working example is provided in the `examples` directory.

--- a/examples/fxa-geodb-example.js
+++ b/examples/fxa-geodb-example.js
@@ -2,18 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var path = require('path');
-// do `npm install fxa-geodb` and then require it using `require('fxa-geodb')`.
-var geoDb = require('../lib/fxa-geodb')({
+const path = require('path');
+const geoDb = require('../lib/fxa-geodb')({
   dbPath: path.join(__dirname, '..', 'db', 'cities-db.mmdb')
 });
-// New York timezone IP: 128.192.8.8
-// Beijing: 123.121.221.194
-// Undefined tz: 64.11.221.194
-// Australia: 137.147.16.179
-geoDb('137.147.16.179')
-  .then(function(location) {
-    console.log(location);
-  }, function (err) {
-    console.log('Err:', err.message);
-  });
+
+try {
+  // New York timezone IP: 128.192.8.8
+  // Beijing: 123.121.221.194
+  // Undefined tz: 64.11.221.194
+  // Australia: 137.147.16.179
+  const location = geoDb('137.147.16.179');
+  console.log(location);
+} catch (err) {
+  console.log('Err:', err.message);
+}

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -5,7 +5,7 @@ var path = require('path');
 
 var DEFAULTS = {
   CRON_TIMING : '30 30 1 * * 3',
-  GEODB_TEST_IP: '8.8.8.8',
+  GEODB_TEST_IP: '63.245.221.32',
   SOURCE_FILE_NAME : 'sources.json',
   TARGET_DIR_NAME : 'db',
   TARGET_FILE_NAME : 'cities-db.mmdb',

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -2,10 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var ERRORS = {
+const ERRORS = {
   'IS_INVALID': 'IP is invalid',
-  'UNABLE_TO_FETCH_DATA': 'Unable to fetch data',
-  'UNABLE_TO_OPEN_FILE': 'Unable to open file'
+  'UNABLE_TO_FETCH_DATA': 'Unable to fetch data'
 };
 
 module.exports = ERRORS;

--- a/lib/fxa-geodb.js
+++ b/lib/fxa-geodb.js
@@ -6,7 +6,6 @@ var DEFAULTS = require('./defaults');
 var ERRORS = require('./errors');
 var maxmind = require('maxmind');
 var Location = require('./location');
-var Promise = require('bluebird');
 
 module.exports = function (options) {
   'use strict';
@@ -14,44 +13,23 @@ module.exports = function (options) {
   options = options || {};
   var dbPath = options.dbPath || DEFAULTS.DB_PATH;
 
-  var dbLookup = null;
-  // we quit if the db did not load for some reason
-  try {
-    dbLookup = maxmind.open(dbPath);
-  } catch (err) {
-    // if it failed with primary database
-    // then reject the promise below
-  }
+  const dbLookup = maxmind.open(dbPath);
 
-  return function (ip, options) {
-    options = options || {};
-    var userLocale = options.userLocale || DEFAULTS.USER_LOCALE;
-    return new Promise(function (resolve, reject) {
-      if (! dbLookup) {
-        return reject({
-          message: ERRORS.UNABLE_TO_OPEN_FILE
-        });
-      }
-      // check if ip is valid
-      if (! maxmind.validate(ip)) {
-        return reject({
-          message: ERRORS.IS_INVALID
-        });
-      }
+  return (ip, options = {}) => {
+    const userLocale = options.userLocale || DEFAULTS.USER_LOCALE;
 
-      var locationData = dbLookup.get(ip);
+    // check if ip is valid
+    if (! maxmind.validate(ip)) {
+      throw new Error(ERRORS.IS_INVALID);
+    }
 
-      if (locationData == null) {
-        return reject({
-          message: ERRORS.UNABLE_TO_FETCH_DATA
-        });
-      }
+    const locationData = dbLookup.get(ip);
+    if (locationData == null) {
+      throw new Error(ERRORS.UNABLE_TO_FETCH_DATA);
+    }
 
-      // return an object with city, country, continent,
-      // latitude, and longitude, and timezone
-      var location = new Location(locationData, userLocale);
-
-      return resolve(location);
-    });
+    // return an object with city, country, continent,
+    // latitude, and longitude, and timezone
+    return new Location(locationData, userLocale);
   };
 };

--- a/lib/maxmind-db-downloader.js
+++ b/lib/maxmind-db-downloader.js
@@ -77,30 +77,27 @@ var MaxmindDbDownloader = function () {
           } else {
             // extraction is complete
             logHelper('info', 'unzip complete');
-            // load up geodb with the downloaded file
-            var geoDb = require('./fxa-geodb')({
-              dbPath: targetFilePathTemp
-            });
-            logHelper('info', 'checking if lookup works with downloaded file');
-            // check if lookup works with the downloaded file
-            geoDb(DEFAULTS.GEODB_TEST_IP)
-              .then(function (location) {
-                // download worked, rename file
-                if (location) {
-                  fs.renameSync(targetFilePathTemp, targetFilePath);
-                  logHelper('info', 'lookup works, renaming downloaded file');
-                }
-                resolve();
-              }, function (err) {
-                // download resulted in an error, do not rename
-                // remove temp file
-                if (fs.existsSync(targetFilePathTemp)) {
-                  fs.unlinkSync(targetFilePathTemp);
-                }
-                logHelper('error', 'downloaded file not working');
-                reject(err);
+            try {
+              // load up geodb with the downloaded file
+              const geoDb = require('./fxa-geodb')({
+                dbPath: targetFilePathTemp
               });
-
+              logHelper('info', 'checking if lookup works with downloaded file');
+              // check if lookup works with the downloaded file
+              geoDb(DEFAULTS.GEODB_TEST_IP);
+              // download worked, rename file
+              fs.renameSync(targetFilePathTemp, targetFilePath);
+              logHelper('info', 'lookup works, renaming downloaded file');
+              resolve();
+            } catch (err) {
+              // download resulted in an error, do not rename
+              // remove temp file
+              if (fs.existsSync(targetFilePathTemp)) {
+                fs.unlinkSync(targetFilePathTemp);
+              }
+              logHelper('error', 'downloaded file not working');
+              reject(err);
+            }
           }
         });
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fxa-geodb",
-  "version": "0.0.8",
+  "version": "1.0.0",
   "private": false,
   "description": "Firefox Accounts GeoDB Repo for Geolocation based services",
   "main": "lib/fxa-geodb.js",

--- a/test/fxa-geodb.js
+++ b/test/fxa-geodb.js
@@ -65,8 +65,8 @@ describe('fxa-geodb', function () {
   it('returns an object with location data when supplied with a valid ip address', function () {
     ip = DEFAULTS.GEODB_TEST_IP;
     var latLong = {
-      latitude: 37.386,
-      longitude: -122.0838
+      latitude: 37.3885,
+      longitude: -122.0741
     };
     return geoDb(ip)
       .then(function (location) {

--- a/test/fxa-geodb.js
+++ b/test/fxa-geodb.js
@@ -2,108 +2,67 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-var chai = require('chai');
-var DEFAULTS = require('../lib/defaults');
-var ERRORS = require('../lib/errors');
-var geoDb;
+const { assert } = require('chai');
+const DEFAULTS = require('../lib/defaults');
+const ERRORS = require('../lib/errors');
 
-var assert = chai.assert;
-
-describe('fxa-geodb', function () {
+describe('fxa-geodb', () => {
   'use strict';
-  var ip;
-  beforeEach(function () {
+
+  let geoDb;
+
+  beforeEach(() => {
     geoDb = require('../lib/fxa-geodb')();
   });
 
-  it('returns a promise when called', function () {
-    assert.isFunction(geoDb('12.23.34.45').then, 'Promise returned');
-  });
-
-  it('returns an error object with `UNABLE_TO_OPEN_FILE` when supplied with an non-existent file', function () {
-    ip = '8.8.8.8';
-    geoDb = require('../lib/fxa-geodb')({
+  it('throws early when supplied with a non-existent file', () => {
+    assert.throws(() => require('../lib/fxa-geodb')({
       dbPath: 'completely-not-there.mmdb'
-    });
-    return geoDb(ip)
-      .catch(function (err) {
-        assert.equal(err.message, ERRORS.UNABLE_TO_OPEN_FILE, 'Invalid error message');
-      });
+    }));
   });
 
-  it('returns an error object with `IS_INVALID` when supplied with an undefined ip variable', function () {
-    return geoDb(ip)
-      .catch(function (err) {
-        assert.equal(err.message, ERRORS.IS_INVALID, 'Invalid error message');
-      });
+  it('throws `IS_INVALID` when supplied with an undefined ip variable', () => {
+    assert.throws(geoDb, Error, ERRORS.IS_INVALID);
   });
 
-  it('returns an error object with `IS_INVALID` when supplied with an object', function () {
-    ip = {};
-    return geoDb(ip)
-      .catch(function (err) {
-        assert.equal(err.message, ERRORS.IS_INVALID, 'Invalid error message');
-      });
+  it('throws `IS_INVALID` when supplied with an object', () => {
+    assert.throws(() => geoDb({}), Error, ERRORS.IS_INVALID);
   });
 
-  it('returns an error object with `IS_INVALID` when supplied with an empty ip', function () {
-    ip = '';
-    return geoDb(ip)
-      .catch(function (err) {
-        assert.equal(err.message, ERRORS.IS_INVALID, 'Invalid error message');
-      });
+  it('throws `IS_INVALID` when supplied with an empty ip', () => {
+    assert.throws(() => geoDb(''), Error, ERRORS.IS_INVALID);
   });
 
-  it('returns an error object with `IS_INVALID` when supplied with an invalid ip', function () {
-    ip = '5.6.7';
-    return geoDb(ip)
-      .catch(function (err) {
-        assert.equal(err.message, ERRORS.IS_INVALID, 'Invalid error message');
-      });
+  it('throws `IS_INVALID` when supplied with an invalid ip', () => {
+    assert.throws(() => geoDb('5.6.7'), Error, ERRORS.IS_INVALID);
   });
 
-  it('returns an object with location data when supplied with a valid ip address', function () {
-    ip = DEFAULTS.GEODB_TEST_IP;
-    var latLong = {
+  it('returns an object with location data when supplied with a valid ip address', () => {
+    const location = geoDb(DEFAULTS.GEODB_TEST_IP);
+
+    assert.equal(location.country, 'United States', 'Country returned correctly');
+    assert.equal(location.countryCode, 'US', 'Country code returned correctly');
+    assert.equal(location.city, 'Mountain View', 'City returned correctly');
+    assert.equal(location.continent, 'North America', 'Continent returned correctly');
+    assert.deepEqual(location.latLong, {
       latitude: 37.3885,
       longitude: -122.0741
-    };
-    return geoDb(ip)
-      .then(function (location) {
-        assert.equal(location.country, 'United States', 'Country returned correctly');
-        assert.equal(location.countryCode, 'US', 'Country code returned correctly');
-        assert.equal(location.city, 'Mountain View', 'City returned correctly');
-        assert.equal(location.continent, 'North America', 'Continent returned correctly');
-        assert.deepEqual(location.latLong, latLong, 'LatLong returned correctly');
-        assert.equal(location.timeZone, 'America/Los_Angeles', 'Timezone returned correctly');
-      }, function (err) {
-        assert.equal(err.message, ERRORS.UNABLE_TO_FETCH_DATA, 'Invalid error message');
-      });
+    }, 'LatLong returned correctly');
+    assert.equal(location.timeZone, 'America/Los_Angeles', 'Timezone returned correctly');
   });
 
-  it('returns an Error Object when no data is available', function () {
-    // 127.0.0.1 is localhost, will always return no data
-    ip = '127.0.0.1';
-    return geoDb(ip)
-      .catch(function (err) {
-        assert.equal(err.message, ERRORS.UNABLE_TO_FETCH_DATA, 'Invalid error message');
-      });
+  it('throws `UNABLE_TO_FETCH_DATA` when no data is available', () => {
+    assert.throws(() => geoDb('127.0.0.1'), Error, ERRORS.UNABLE_TO_FETCH_DATA);
   });
 
-  it('returns an object with partial location data when complete data is not available', function () {
+  it('returns an object with partial location data when complete data is not available', () => {
     // 64.11.221.194 is an unassigned IP in North America, will probably return incomplete data
-    // time_zone and city should be undefined, while country would be USA
-    ip = '64.11.221.194';
-    return geoDb(ip)
-      .then(function (location) {
-        assert.equal(location.country, 'United States', 'Country returned correctly');
-        assert.equal(location.countryCode, 'US', 'Country code returned correctly');
-        assert.equal(typeof location.city, 'undefined', 'City undefined');
-        assert.equal(location.continent, 'North America', 'Continent returned correctly');
-        assert.equal(typeof location.timeZone, 'undefined', 'Timezone undefined');
-      }, function (err) {
-        assert.equal(err.message, ERRORS.UNABLE_TO_FETCH_DATA, 'Invalid error message');
-      });
-  });
+    const location = geoDb('64.11.221.194');
 
+    assert.equal(location.country, 'United States', 'Country returned correctly');
+    assert.equal(location.countryCode, 'US', 'Country code returned correctly');
+    assert.equal(location.city, undefined, 'City undefined');
+    assert.equal(location.continent, 'North America', 'Continent returned correctly');
+    assert.equal(location.timeZone, undefined, 'Timezone undefined');
+  });
 });


### PR DESCRIPTION
Fixes #30.

The core functionality of this repo isn't asynchronous, so there's no reason to return a promise. And because promises ripple outwards, returning a promise has led to some ugly code in the auth server, where we expose the result on the request object. Everywhere we use it has to do this:

```js
request.app.geo.then(geoData => {
  // use geoData...
});
```

It would be much nicer if we could just use `request.app.geo` directly, hence this PR.

Obviously, ditching promises is a breaking change to the API, so I've included a major version bump. And CI has been updated to run on node 6 and 8, too.

This PR also includes the test fix from #31, so I'll close that one and we can just bring the fix in here instead.

@mozilla/fxa-devs r?