### PR TITLE
fix(download): fix "TypeError: log[type] is not a function"

### DIFF
--- a/lib/maxmind-db-downloader.js
+++ b/lib/maxmind-db-downloader.js
@@ -16,7 +16,8 @@ var zlib = require('zlib');
 // set up mozlog, default is `heka`
 var log = mozlog({
   app: 'fxa-geodb'
-});
+})();
+
 var isTestEnv = (process.env.NODE_ENV === 'test') || process.env.CI;
 var isLogQuiet = (process.env.LOG === 'quiet');
 


### PR DESCRIPTION
On npm postinstall, it runs `LOG=quiet node scripts/start-db-download.js`.

The crashes with 'TypeError: log[type] is not a function' but `LOG=quiet` silences that.

Anyways, this crash means that content server on `latest`, etc., can no longer start, as it tries to load ENOENT on startup.

I'm actually just guessing this is the right fix, but if it is can someone merge and push a new release and update fxa-content-server? /cc @mozilla/fxa-devs 